### PR TITLE
Avoid double bump

### DIFF
--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -87,6 +87,7 @@ module GitVersion
           nil,
         )
 
+      major = false
       get_bumps(latestTaggedVersion).each do |bump|
         commit = bump.downcase
         if commit.includes?(MAJOR_BUMP_COMMENT)
@@ -98,17 +99,25 @@ module GitVersion
               latestVersion.prerelease,
               latestVersion.build,
             )
+          major = true
+          break
         end
+      end
 
-        if commit.includes?(MINOR_BUMP_COMMENT)
-          latestVersion =
-            SemanticVersion.new(
-              latestVersion.major,
-              latestVersion.minor + 1,
-              0,
-              latestVersion.prerelease,
-              latestVersion.build,
-            )
+      if !major
+        get_bumps(latestTaggedVersion).each do |bump|
+          commit = bump.downcase
+          if commit.includes?(MINOR_BUMP_COMMENT)
+            latestVersion =
+              SemanticVersion.new(
+                latestVersion.major,
+                latestVersion.minor + 1,
+                0,
+                latestVersion.prerelease,
+                latestVersion.build,
+              )
+            break
+          end
         end
       end
 


### PR DESCRIPTION
This is a Fix proposal for #9 

The logic slightly changed in this way:
Looking at the commit messages since last tag ->
if exists at least one `breaking` we bump by one 1 the major
if exists at least one `feature` and there are no `breaking` we bump by one the minor

This should prevent accidental multiple bumps.