### PR TITLE
Use which to detect the crystal compiler path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CRYSTAL=/usr/bin/crystal
+CRYSTAL?=$(shell which crystal)
 CRYSTAL_FLAGS=--release
 
 VERSION?=$(shell ./bin/git-version)


### PR DESCRIPTION
On some OSs the compiler might not be installed in `/usr/bin/crystal`. In macOS, if you use homebrew, it ends up in `$(brew --prefix)/bin/crystal`, where the prefix is generally `/usr/local`