### PR TITLE
fix: Fix branch name detection using a more reliable command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,10 @@ references:
     run:
       name: Get version
       command: |
-        curl -sSL https://dist.crystal-lang.org/apt/setup.sh | sudo bash
         sudo apt-get update
-        sudo apt-get install crystal libevent-core-2.0-5 libevent-dev libevent-extra-2.0-5 libevent-openssl-2.0-5 libevent-pthreads-2.0-5 libgmp-dev libgmpxx4ldbl libssl-dev libxml2-dev libyaml-dev libreadline-dev automake libtool git llvm libpcre3-dev build-essential -y
+        sudo apt-get install libevent-core-2.0-5 libevent-dev libevent-extra-2.0-5 libevent-openssl-2.0-5 libevent-pthreads-2.0-5 libgmp-dev libgmpxx4ldbl libssl-dev libxml2-dev libyaml-dev libreadline-dev automake libtool git llvm libpcre3-dev build-essential -y
+        wget https://github.com/crystal-lang/crystal/releases/download/0.30.1/crystal_0.30.1-1_amd64.deb
+        sudo dpkg -i crystal_0.30.1-1_amd64.deb
         sudo make clean test build
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM codacy/ci-base:1.0.1 AS builder
+FROM codacy/ci-base:2.0.0 AS builder
 
 RUN apk add --update --no-cache --force-overwrite \
     openssl openssl-dev crystal shards g++ gc-dev \
     libc-dev libevent-dev libxml2-dev llvm llvm-dev \
-    llvm-libs llvm-static make pcre-dev readline-dev \
+    llvm-static make pcre-dev readline-dev \
     yaml-dev zlib-dev git
 
 RUN  git config --global user.email "team@codacy.com" && git config --global user.name "Codacy"
@@ -19,7 +19,7 @@ RUN make test build
 
 
 
-FROM codacy/ci-base:1.0.1
+FROM codacy/ci-base:2.0.0
 
 LABEL maintainer="team@codacy.com"
 

--- a/spec/git-version-spec.cr
+++ b/spec/git-version-spec.cr
@@ -9,434 +9,500 @@ describe GitVersion do
   it "should get the correct version in master and dev branch" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "1.0.0")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "1.0.0")
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("1.0.1")
+      version.should eq("1.0.1")
 
-    tmp.exec %(git checkout -b dev)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
+      tmp.exec %(git checkout -b dev)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
 
-    tag_on_master = git.tags_by_branch("master")
+      tag_on_master = git.tags_by_branch("master")
 
-    tag_on_master.should eq(["1.0.0"])
+      tag_on_master.should eq(["1.0.0"])
 
-    current_branch = git.current_branch
+      current_branch = git.current_branch_or_tag
 
-    current_branch.should eq("dev")
+      current_branch.should eq("dev")
 
-    hash = git.current_commit_hash
+      hash = git.current_commit_hash
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("1.0.1-SNAPSHOT.#{hash}")
+      version.should eq("1.0.1-SNAPSHOT.#{hash}")
 
-    tmp.exec %(git checkout -b feature-branch)
-    tmp.exec %(touch file2.txt)
-    tmp.exec %(git add file2.txt)
-    tmp.exec %(git commit --no-gpg-sign -m "new file2.txt")
+      tmp.exec %(git checkout -b feature-branch)
+      tmp.exec %(touch file2.txt)
+      tmp.exec %(git add file2.txt)
+      tmp.exec %(git commit --no-gpg-sign -m "new file2.txt")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "should get the correct version feature branch" do
     tmp = InTmp.new
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "1.0.0")
+    begin
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "1.0.0")
 
-    tmp.exec %(git checkout -b my-fancy.branch)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
+      tmp.exec %(git checkout -b my-fancy.branch)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    hash = git.current_commit_hash
+      hash = git.current_commit_hash
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("1.0.1-myfancybranch.#{hash}")
+      version.should eq("1.0.1-myfancybranch.#{hash}")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "should properly bump the version" do
     tmp = InTmp.new
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "1.0.0")
+    begin
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "1.0.0")
 
-    tmp.exec %(git checkout -b dev)
+      tmp.exec %(git checkout -b dev)
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: XYZ")
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: XYZ")
 
-    hash = git.current_commit_hash
+      hash = git.current_commit_hash
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("2.0.0-SNAPSHOT.#{hash}")
+      version.should eq("2.0.0-SNAPSHOT.#{hash}")
 
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: XYZ")
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: XYZ")
 
-    hash = git.current_commit_hash
+      hash = git.current_commit_hash
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("2.0.0-SNAPSHOT.#{hash}")
+      version.should eq("2.0.0-SNAPSHOT.#{hash}")
 
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "feature: XYZ")
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "feature: XYZ")
 
-    hash = git.current_commit_hash
+      hash = git.current_commit_hash
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("2.0.0-SNAPSHOT.#{hash}")
+      version.should eq("2.0.0-SNAPSHOT.#{hash}")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "bump on master after merging in various ways" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "1.0.0")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "1.0.0")
 
-    tmp.exec %(git checkout -b my-fancy.branch)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
+      tmp.exec %(git checkout -b my-fancy.branch)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
 
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: XYZ")
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: XYZ")
 
-    tmp.exec %(git checkout master)
+      tmp.exec %(git checkout master)
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("1.0.1")
+      version.should eq("1.0.1")
 
-    tmp.exec %(git merge my-fancy.branch)
+      tmp.exec %(git merge my-fancy.branch)
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("2.0.0")
+      version.should eq("2.0.0")
 
-    tmp.exec %(git tag "2.0.0")
+      tmp.exec %(git tag "2.0.0")
 
-    tmp.exec %(git checkout -b my-fancy.branch2)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: ABC")
-    tmp.exec %(git checkout master)
+      tmp.exec %(git checkout -b my-fancy.branch2)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: ABC")
+      tmp.exec %(git checkout master)
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("2.0.1")
+      version.should eq("2.0.1")
 
-    tmp.exec %(git merge --ff-only my-fancy.branch2)
+      tmp.exec %(git merge --ff-only my-fancy.branch2)
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("3.0.0")
+      version.should eq("3.0.0")
 
-    tmp.exec %(git tag "3.0.0")
+      tmp.exec %(git tag "3.0.0")
 
-    tmp.exec %(git checkout -b my-fancy.branch3)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "feature: 123")
-    tmp.exec %(git checkout master)
+      tmp.exec %(git checkout -b my-fancy.branch3)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "feature: 123")
+      tmp.exec %(git checkout master)
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("3.0.1")
+      version.should eq("3.0.1")
 
-    tmp.exec %(git merge --no-gpg-sign --no-ff my-fancy.branch3)
+      tmp.exec %(git merge --no-gpg-sign --no-ff my-fancy.branch3)
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("3.1.0")
+      version.should eq("3.1.0")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "correct version on feature after second commit" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "1.0.0")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "1.0.0")
 
-    tmp.exec %(# Checkout to dev)
-    tmp.exec %(git checkout -b dev)
+      tmp.exec %(# Checkout to dev)
+      tmp.exec %(git checkout -b dev)
 
-    # Checkout to FT-1111 from dev and add a commit)
-    tmp.exec %(git checkout -b FT-1111)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "3")
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "4")
+      # Checkout to FT-1111 from dev and add a commit)
+      tmp.exec %(git checkout -b FT-1111)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "3")
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "4")
 
-    hash = git.current_commit_hash
+      hash = git.current_commit_hash
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("1.0.1-ft1111.#{hash}")
+      version.should eq("1.0.1-ft1111.#{hash}")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "should retrieve correct first version on master" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("0.0.1")
+      version.should eq("0.0.1")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "version properly after 5th commit" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
-    tmp.exec %(git tag "1.1.0")
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "3")
-    tmp.exec %(git tag "1.2.0")
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "4")
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "5")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
+      tmp.exec %(git tag "1.1.0")
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "3")
+      tmp.exec %(git tag "1.2.0")
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "4")
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "5")
 
-    version = git.get_version
+      version = git.get_version
 
-    version.should eq("1.2.1")
+      version.should eq("1.2.1")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "version properly with concurrent features" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "1.0.0")
-    tmp.exec %(git checkout -b feature1)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "feature: 2")
-    hash = git.current_commit_hash
-    version = git.get_version
-    version.should eq("1.1.0-feature1.#{hash}")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "1.0.0")
+      tmp.exec %(git checkout -b feature1)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "feature: 2")
+      hash = git.current_commit_hash
+      version = git.get_version
+      version.should eq("1.1.0-feature1.#{hash}")
 
-    tmp.exec %(git checkout master)
-    tmp.exec %(git checkout -b feature2)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: 3")
-    hash = git.current_commit_hash
-    version = git.get_version
-    version.should eq("2.0.0-feature2.#{hash}")
+      tmp.exec %(git checkout master)
+      tmp.exec %(git checkout -b feature2)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: 3")
+      hash = git.current_commit_hash
+      version = git.get_version
+      version.should eq("2.0.0-feature2.#{hash}")
 
-    tmp.exec %(git checkout master)
-    tmp.exec %(git merge feature2)
-    version = git.get_version
-    version.should eq("2.0.0")
-    tmp.exec %(git tag "2.0.0")
+      tmp.exec %(git checkout master)
+      tmp.exec %(git merge feature2)
+      version = git.get_version
+      version.should eq("2.0.0")
+      tmp.exec %(git tag "2.0.0")
 
-    tmp.exec %(git checkout -b feature3)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "4")
-    hash = git.current_commit_hash
-    version = git.get_version
-    version.should eq("2.0.1-feature3.#{hash}")
+      tmp.exec %(git checkout -b feature3)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "4")
+      hash = git.current_commit_hash
+      version = git.get_version
+      version.should eq("2.0.1-feature3.#{hash}")
 
-    tmp.exec %(git checkout master)
-    tmp.exec %(git merge --no-gpg-sign feature1)
-    version = git.get_version
-    version.should eq("2.1.0")
-    tmp.exec %(git tag "2.1.0")
+      tmp.exec %(git checkout master)
+      tmp.exec %(git merge --no-gpg-sign feature1)
+      version = git.get_version
+      version.should eq("2.1.0")
+      tmp.exec %(git tag "2.1.0")
 
-    tmp.exec %(git merge --no-gpg-sign feature3)
-    version = git.get_version
-    version.should eq("2.1.1")
-    tmp.exec %(git tag "2.1.1")
+      tmp.exec %(git merge --no-gpg-sign feature3)
+      version = git.get_version
+      version.should eq("2.1.1")
+      tmp.exec %(git tag "2.1.1")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "version releases with rebase from master" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "1.0.0")
-    tmp.exec %(git checkout -b dev)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
-    hash = git.current_commit_hash
-    version = git.get_version
-    version.should eq("1.0.1-SNAPSHOT.#{hash}")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "1.0.0")
+      tmp.exec %(git checkout -b dev)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
+      hash = git.current_commit_hash
+      version = git.get_version
+      version.should eq("1.0.1-SNAPSHOT.#{hash}")
 
-    tmp.exec %(git checkout -b myfeature)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "3")
-    tmp.exec %(git checkout dev)
-    tmp.exec %(git merge myfeature)
+      tmp.exec %(git checkout -b myfeature)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "3")
+      tmp.exec %(git checkout dev)
+      tmp.exec %(git merge myfeature)
 
-    tmp.exec %(git checkout master)
-    tmp.exec %(git rebase dev)
-    version = git.get_version
-    version.should eq("1.0.1")
+      tmp.exec %(git checkout master)
+      tmp.exec %(git rebase dev)
+      version = git.get_version
+      version.should eq("1.0.1")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "bump version only once in presence of merge commit message" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "1.0.0")
-    tmp.exec %(git checkout -b dev)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: 2")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "1.0.0")
+      tmp.exec %(git checkout -b dev)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: 2")
 
-    tmp.exec %(git checkout master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "3")
+      tmp.exec %(git checkout master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "3")
 
-    tmp.exec %(git checkout dev)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "4")
-    tmp.exec %(git rebase master)
+      tmp.exec %(git checkout dev)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "4")
+      tmp.exec %(git rebase master)
 
-    tmp.exec %(git checkout master)
-    tmp.exec %(git merge --no-gpg-sign --no-ff dev)
-    # e.g. commit added when merging by bitbucket, no easy way to produce it automatically...
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "Merged xyz (123) breaking:")
+      tmp.exec %(git checkout master)
+      tmp.exec %(git merge --no-gpg-sign --no-ff dev)
+      # e.g. commit added when merging by bitbucket, no easy way to produce it automatically...
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "Merged xyz (123) breaking:")
 
-    version = git.get_version
-    version.should eq("2.0.0")
+      version = git.get_version
+      version.should eq("2.0.0")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "when in master should not consider pre-release versions for major bumps" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "1.0.0")
-    tmp.exec %(git checkout -b dev)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: 2")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "1.0.0")
+      tmp.exec %(git checkout -b dev)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: 2")
 
-    version = git.get_version
-    hash = git.current_commit_hash
-    tmp.exec %(git tag "#{version}")
-    version.should eq("2.0.0-SNAPSHOT.#{hash}")
+      version = git.get_version
+      hash = git.current_commit_hash
+      tmp.exec %(git tag "#{version}")
+      version.should eq("2.0.0-SNAPSHOT.#{hash}")
 
-    tmp.exec %(git checkout master)
-    tmp.exec %(git merge --no-gpg-sign --no-ff dev)
+      tmp.exec %(git checkout master)
+      tmp.exec %(git merge --no-gpg-sign --no-ff dev)
 
-    version = git.get_version
-    version.should eq("2.0.0")
+      version = git.get_version
+      version.should eq("2.0.0")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "when in master should not consider pre-release versions for minor bumps" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "1.0.0")
-    tmp.exec %(git checkout -b dev)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "1.0.0")
+      tmp.exec %(git checkout -b dev)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
 
-    version = git.get_version
-    hash = git.current_commit_hash
-    tmp.exec %(git tag "#{version}")
-    version.should eq("1.0.1-SNAPSHOT.#{hash}")
+      version = git.get_version
+      hash = git.current_commit_hash
+      tmp.exec %(git tag "#{version}")
+      version.should eq("1.0.1-SNAPSHOT.#{hash}")
 
-    tmp.exec %(git checkout master)
-    tmp.exec %(git merge --no-gpg-sign --no-ff dev)
+      tmp.exec %(git checkout master)
+      tmp.exec %(git merge --no-gpg-sign --no-ff dev)
 
-    version = git.get_version
-    version.should eq("1.0.1")
+      version = git.get_version
+      version.should eq("1.0.1")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "bump properly major and reset minor" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "0.1.0")
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m ":breaking: 2")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "0.1.0")
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m ":breaking: 2")
 
-    version = git.get_version
-    version.should eq("1.0.0")
+      version = git.get_version
+      version.should eq("1.0.0")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "should bump the breaking even with a pre-release tag" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
-    tmp.exec %(git tag "0.1.0-asd")
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m ":breaking: 2")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
+      tmp.exec %(git tag "0.1.0-asd")
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m ":breaking: 2")
 
-    version = git.get_version
-    version.should eq("1.0.0")
+      version = git.get_version
+      version.should eq("1.0.0")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
   end
 
   it "should bump the breaking even without any other tag" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
 
-    tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
-    tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: 1")
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: 1")
 
-    version = git.get_version
-    version.should eq("1.0.0")
+      version = git.get_version
+      version.should eq("1.0.0")
 
-    tmp.cleanup
+    ensure
+      tmp.cleanup
+    end
+  end
+
+  it "should fallback to tag detection if in detached HEAD(on a tag)" do
+    tmp = InTmp.new
+
+    begin
+      git = GitVersion::Git.new("dev", tmp.@tmpdir)
+
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: 1")
+      tmp.exec %(git tag v1)
+      tmp.exec %(git checkout v1)
+
+      version = git.get_version
+      hash = git.current_commit_hash
+      version.should eq("1.0.0-v1.#{hash}")
+
+    ensure
+      tmp.cleanup
+    end
   end
 end

--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -40,8 +40,10 @@ module GitVersion
       return exec "git tag --merged #{branch}"
     end
 
-    def current_branch
+    def current_branch_or_tag
       return (exec "git symbolic-ref --short HEAD")[0]
+    rescue
+      return (exec "git describe --tags")[0]
     end
 
     def current_commit_hash : String
@@ -62,7 +64,7 @@ module GitVersion
     end
 
     def get_version
-      cb = current_branch
+      cb = current_branch_or_tag
 
       branch_tags = tags_by_branch(cb)
 


### PR DESCRIPTION
waiting for this:
https://github.com/codacy/ci-base/pull/7

This fix the detection of the current branch when in detached HEAD mode (e.g.: when checking out a tag) and fallback to the tag name.