### PR TITLE
feature: allow a custom master/release branch to be provided

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CRYSTAL=/usr/bin/crystal
+CRYSTAL?=$(shell which crystal)
 CRYSTAL_FLAGS=--release
 
 VERSION?=$(shell ./bin/git-version)

--- a/spec/git-version-spec.cr
+++ b/spec/git-version-spec.cr
@@ -6,13 +6,13 @@ require "../src/git-version"
 
 include Utils
 describe GitVersion do
-  it "should get the correct version in master and dev branch" do
+  it "should get the correct version in release and dev branches" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
-    tmp.exec %(git checkout -b master)
+    tmp.exec %(git checkout -b #{git.release_branch})
     tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "1")
     tmp.exec %(git tag "1.0.0")
 
@@ -20,16 +20,16 @@ describe GitVersion do
 
     version.should eq("1.0.1")
 
-    tmp.exec %(git checkout -b dev)
+    tmp.exec %(git checkout -b #{git.dev_branch})
     tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
 
-    tag_on_master = git.tags_by_branch("master")
+    tag_on_master = git.tags_by_branch("#{git.release_branch}")
 
     tag_on_master.should eq(["1.0.0"])
 
     current_branch = git.current_branch
 
-    current_branch.should eq("dev")
+    current_branch.should eq("#{git.dev_branch}")
 
     hash = git.current_commit_hash
 
@@ -56,7 +56,7 @@ describe GitVersion do
     tmp.exec %(git checkout -b my-fancy.branch)
     tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     hash = git.current_commit_hash
 
@@ -77,7 +77,7 @@ describe GitVersion do
 
     tmp.exec %(git checkout -b dev)
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: XYZ")
 
@@ -109,7 +109,7 @@ describe GitVersion do
   it "bump on master after merging in various ways" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -171,7 +171,7 @@ describe GitVersion do
   it "correct version on feature after second commit" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -198,7 +198,7 @@ describe GitVersion do
   it "should retrieve correct first version on master" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -214,7 +214,7 @@ describe GitVersion do
   it "version properly after 5th commit" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -236,7 +236,7 @@ describe GitVersion do
   it "version properly with concurrent features" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -284,7 +284,7 @@ describe GitVersion do
   it "version releases with rebase from master" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -312,7 +312,7 @@ describe GitVersion do
   it "bump version only once in presence of merge commit message" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -342,7 +342,7 @@ describe GitVersion do
   it "when in master should not consider pre-release versions for major bumps" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -368,7 +368,7 @@ describe GitVersion do
   it "when in master should not consider pre-release versions for minor bumps" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -394,7 +394,7 @@ describe GitVersion do
   it "bump properly major and reset minor" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -411,7 +411,7 @@ describe GitVersion do
   it "should bump the breaking even with a pre-release tag" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -428,7 +428,7 @@ describe GitVersion do
   it "should bump the breaking even without any other tag" do
     tmp = InTmp.new
 
-    git = GitVersion::Git.new("dev", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)

--- a/spec/git-version-spec.cr
+++ b/spec/git-version-spec.cr
@@ -27,7 +27,7 @@ describe GitVersion do
 
     tag_on_master.should eq(["1.0.0"])
 
-    current_branch = git.current_branch
+    current_branch = git.current_branch_or_tag
 
     current_branch.should eq("#{git.dev_branch}")
 

--- a/src/entrypoint/git-version.cr
+++ b/src/entrypoint/git-version.cr
@@ -5,12 +5,15 @@ require "file_utils"
 require "../git-version"
 
 dev_branch = "dev"
+release_branch = "master"
+
 folder = FileUtils.pwd
 
 OptionParser.parse! do |parser|
   parser.banner = "Usage: git-version [arguments]"
   parser.on("-f FOLDER", "--folder=FOLDER", "Execute the command in the defined folder") { |f| folder = f }
   parser.on("-b BRANCH", "--dev-branch=BRANCH", "Specifies the development branch") { |branch| dev_branch = branch }
+  parser.on("-rb BRANCH", "--release-branch=BRANCH", "Specifies the release branch") { |branch| release_branch = branch }
   parser.on("-h", "--help", "Show this help") { puts parser }
   parser.invalid_option do |flag|
     STDERR.puts "ERROR: #{flag} is not a valid option."
@@ -19,6 +22,6 @@ OptionParser.parse! do |parser|
   end
 end
 
-git = GitVersion::Git.new(dev_branch, folder)
+git = GitVersion::Git.new(dev_branch, release_branch, folder)
 
 puts "#{git.get_version}"

--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -14,7 +14,7 @@ module GitVersion
   MINOR_BUMP_COMMENT = "feature:"
 
   class Git
-    def initialize(@dev_branch : String, @release_branch : String, @folder = FileUtils.pwd)
+    def initialize(@dev_branch : String, @release_branch : String = "master" , @folder = FileUtils.pwd)
       #
     end
 
@@ -46,8 +46,10 @@ module GitVersion
       return exec "git tag --merged #{branch}"
     end
 
-    def current_branch
+    def current_branch_or_tag
       return (exec "git symbolic-ref --short HEAD")[0]
+    rescue
+      return (exec "git describe --tags")[0]
     end
 
     def current_commit_hash : String
@@ -68,7 +70,7 @@ module GitVersion
     end
 
     def get_version
-      cb = current_branch
+      cb = current_branch_or_tag
 
       branch_tags = tags_by_branch(cb)
 

--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -10,13 +10,11 @@ module GitVersion
 
   DEV_BRANCH_SUFFIX = "SNAPSHOT"
 
-  MASTER_BRANCH = "master"
-
   MAJOR_BUMP_COMMENT = "breaking:"
   MINOR_BUMP_COMMENT = "feature:"
 
   class Git
-    def initialize(@dev_branch : String, @folder = FileUtils.pwd)
+    def initialize(@dev_branch : String, @release_branch : String, @folder = FileUtils.pwd)
       #
     end
 
@@ -34,6 +32,14 @@ module GitVersion
       end
 
       return strout.to_s.split('\n', remove_empty: true)
+    end
+
+    def dev_branch
+      return @dev_branch
+    end
+
+    def release_branch
+      return @release_branch
     end
 
     def tags_by_branch(branch)
@@ -126,7 +132,7 @@ module GitVersion
         end
       end
 
-      if cb == MASTER_BRANCH
+      if cb == @release_branch
         #
       elsif cb == @dev_branch
         prerelease = [DEV_BRANCH_SUFFIX, current_commit_hash()] of String | Int32


### PR DESCRIPTION
The reason behind this addition is that we would like to use another branch for releases other than master.