### PR TITLE
[Proposal] feature: Add an optional patch command

### DIFF
--- a/spec/git-version-spec.cr
+++ b/spec/git-version-spec.cr
@@ -10,7 +10,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b #{git.release_branch})
@@ -60,7 +60,7 @@ describe GitVersion do
       tmp.exec %(git checkout -b my-fancy.branch)
       tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "2")
 
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       hash = git.current_commit_hash
 
@@ -84,7 +84,7 @@ describe GitVersion do
 
       tmp.exec %(git checkout -b dev)
 
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: XYZ")
 
@@ -119,7 +119,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -184,7 +184,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -214,7 +214,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -233,7 +233,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -258,7 +258,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -309,7 +309,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -340,7 +340,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -373,7 +373,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -402,7 +402,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -431,7 +431,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -451,7 +451,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -471,7 +471,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -489,7 +489,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", nil, tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -501,6 +501,24 @@ describe GitVersion do
       hash = git.current_commit_hash
       version.should eq("1.0.0-v1.#{hash}")
 
+    ensure
+      tmp.cleanup
+    end
+  end
+
+  it "should increase the patch release if the patch command exit with 0" do
+    tmp = InTmp.new
+
+    begin
+      git = GitVersion::Git.new("dev", "master", "if [ \"1.0.0\" = \"<version>\" ]; then exit 0; else exit 1; fi", tmp.@tmpdir)
+
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b master)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: 1")
+
+      version = git.get_version
+      hash = git.current_commit_hash
+      version.should eq("1.0.1")
     ensure
       tmp.cleanup
     end

--- a/spec/git-version-spec.cr
+++ b/spec/git-version-spec.cr
@@ -42,7 +42,6 @@ describe GitVersion do
       tmp.exec %(touch file2.txt)
       tmp.exec %(git add file2.txt)
       tmp.exec %(git commit --no-gpg-sign -m "new file2.txt")
-
     ensure
       tmp.cleanup
     end
@@ -67,7 +66,6 @@ describe GitVersion do
       version = git.get_version
 
       version.should eq("1.0.1-myfancybranch.#{hash}")
-
     ensure
       tmp.cleanup
     end
@@ -109,7 +107,6 @@ describe GitVersion do
       version = git.get_version
 
       version.should eq("2.0.0-SNAPSHOT.#{hash}")
-
     ensure
       tmp.cleanup
     end
@@ -174,7 +171,6 @@ describe GitVersion do
       version = git.get_version
 
       version.should eq("3.1.0")
-
     ensure
       tmp.cleanup
     end
@@ -204,7 +200,6 @@ describe GitVersion do
       version = git.get_version
 
       version.should eq("1.0.1-ft1111.#{hash}")
-
     ensure
       tmp.cleanup
     end
@@ -223,7 +218,6 @@ describe GitVersion do
       version = git.get_version
 
       version.should eq("0.0.1")
-
     ensure
       tmp.cleanup
     end
@@ -248,7 +242,6 @@ describe GitVersion do
       version = git.get_version
 
       version.should eq("1.2.1")
-
     ensure
       tmp.cleanup
     end
@@ -299,7 +292,6 @@ describe GitVersion do
       version = git.get_version
       version.should eq("2.1.1")
       tmp.exec %(git tag "2.1.1")
-
     ensure
       tmp.cleanup
     end
@@ -330,7 +322,6 @@ describe GitVersion do
       tmp.exec %(git rebase dev)
       version = git.get_version
       version.should eq("1.0.1")
-
     ensure
       tmp.cleanup
     end
@@ -363,7 +354,6 @@ describe GitVersion do
 
       version = git.get_version
       version.should eq("2.0.0")
-
     ensure
       tmp.cleanup
     end
@@ -392,7 +382,6 @@ describe GitVersion do
 
       version = git.get_version
       version.should eq("2.0.0")
-
     ensure
       tmp.cleanup
     end
@@ -421,7 +410,6 @@ describe GitVersion do
 
       version = git.get_version
       version.should eq("1.0.1")
-
     ensure
       tmp.cleanup
     end
@@ -441,7 +429,6 @@ describe GitVersion do
 
       version = git.get_version
       version.should eq("1.0.0")
-
     ensure
       tmp.cleanup
     end
@@ -461,7 +448,6 @@ describe GitVersion do
 
       version = git.get_version
       version.should eq("1.0.0")
-
     ensure
       tmp.cleanup
     end
@@ -479,7 +465,6 @@ describe GitVersion do
 
       version = git.get_version
       version.should eq("1.0.0")
-
     ensure
       tmp.cleanup
     end
@@ -500,7 +485,6 @@ describe GitVersion do
       version = git.get_version
       hash = git.current_commit_hash
       version.should eq("1.0.0-v1.#{hash}")
-
     ensure
       tmp.cleanup
     end
@@ -517,7 +501,6 @@ describe GitVersion do
       tmp.exec %(git commit --no-gpg-sign --allow-empty --no-gpg-sign -m "breaking: 1")
 
       version = git.get_version
-      hash = git.current_commit_hash
       version.should eq("1.0.1")
     ensure
       tmp.cleanup

--- a/src/entrypoint/git-version.cr
+++ b/src/entrypoint/git-version.cr
@@ -6,6 +6,7 @@ require "../git-version"
 
 dev_branch = "dev"
 release_branch = "master"
+patch_cmd = nil
 
 folder = FileUtils.pwd
 
@@ -14,6 +15,7 @@ OptionParser.parse! do |parser|
   parser.on("-f FOLDER", "--folder=FOLDER", "Execute the command in the defined folder") { |f| folder = f }
   parser.on("-b BRANCH", "--dev-branch=BRANCH", "Specifies the development branch") { |branch| dev_branch = branch }
   parser.on("-r BRANCH", "--release-branch=BRANCH", "Specifies the release branch") { |branch| release_branch = branch }
+  parser.on("-p PATCHCMD", "--patch-command=BRANCH", "Specifies the command to run to bump the minor") { |patchcmd| patch_cmd = patchcmd }
   parser.on("-h", "--help", "Show this help") { puts parser }
   parser.invalid_option do |flag|
     STDERR.puts "ERROR: #{flag} is not a valid option."
@@ -22,6 +24,6 @@ OptionParser.parse! do |parser|
   end
 end
 
-git = GitVersion::Git.new(dev_branch, release_branch, folder)
+git = GitVersion::Git.new(dev_branch, release_branch, patch_cmd, folder)
 
 puts "#{git.get_version}"

--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -18,7 +18,7 @@ module GitVersion
       #
     end
 
-    private def attemptExec(cmd, ver)
+    private def attempt_exec(cmd, ver)
       if cmd
         puts cmd.gsub("<version>", ver)
         Process.run(
@@ -173,7 +173,7 @@ module GitVersion
           )
       end
 
-      while attemptExec(@patch_cmd, latest_version.to_s)
+      while attempt_exec(@patch_cmd, latest_version.to_s)
         latest_version =
           SemanticVersion.new(
             latest_version.major,


### PR DESCRIPTION
This PR proposes a possible approach to address the following concerns:
 - avoid to tag with failing deployments
 - recover from partial publish
 - have monotonically incremental versions regardless from CI failures
 - ability to re-run workflows in development environments 

The most common use case in Codacy is to have a release partially published in which case we can craft a "patch_cmd" that will check the presence of the first deployed artifact to sonatype.
E.g:
```bash
if [ "$(curl -s -o /dev/null -I -w '%{http_code}' https://oss.sonatype.org/content/repositories/public/com/codacy/artifact-name/<version>)" == "302" ]; then exit 0; else exit 1; fi
```
Alternatively we can verify the presence of the docker image or something else.

The code is sketched up to serve as a working demonstration I will clean it up if we decide to go ahead with this approach.