### PR TITLE
add sha prefix to hash

### DIFF
--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -67,7 +67,8 @@ module GitVersion
 
     def current_commit_hash : String
       cmd = "git rev-parse --verify HEAD --short"
-      return (exec cmd)[0].rjust(7, '0')
+      sha = (exec cmd)[0].rjust(7, '0')
+      return "SHA" + sha
     end
 
     def commits_distance(latest_tagged_version)


### PR DESCRIPTION
We can't have leading zeros

<img width="750" alt="image" src="https://user-images.githubusercontent.com/3610528/92946905-922d5d00-f457-11ea-95b9-ce7df4bf350d.png">

This fails to parse and is giving us a lot of problems on helm.


![image](https://user-images.githubusercontent.com/3610528/92946950-a40f0000-f457-11ea-98aa-a1f84b79431c.png)
