### PR TITLE
fix signal 11 due to multiple slashes in branch name

### DIFF
--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -56,7 +56,7 @@ module GitVersion
     end
 
     def tags_by_branch(branch)
-      return exec "git tag --merged #{branch}"
+      return exec "git tag --merged refs/remotes/origin/#{branch}"
     end
 
     def current_branch_or_tag


### PR DESCRIPTION
fix `Invalid memory access (signal 11) at address 0x0` due to multiple slashes in branch name.

eg: `feature/XYZ` works, but `feature/XYZ-123/zxc` throws `Invalid memory access (signal 11) at address 0x0`

could probably use iteration over all available remotes, but I am not proficient enough in Crystal to fix that