### PR TITLE
feat: make minor and major bump identifiers configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ $ ./git-version
 1.0.0
 ```
 
-Versions are incremented since the last tag. The patch version is incremented by default, unless there is at least one commit since the last tag, containing `feature:` or `breaking:` in the message.
+Versions are incremented since the last tag. The patch version is incremented by default, unless there is at least one commit since the last tag, containing a minor or major identifier (defaults to `feature:` or `breaking:`) in the message.
 
-On branches other than master and `dev` the version is a variation of the latest common tag with master, and has the following format:
+On branches other than the master/main and development branch (default to `master` and `dev`) the version is a variation of the latest common tag with the master/main branch, and has the following format:
 
 `{MAJOR}.{MINOR}.{PATCH}-{sanitized-branch-name}.{commits-distance}.{hash}`
 
-On the `dev` branch the format is the following:
+On the development branch the format is the following:
 
 `{MAJOR}.{MINOR}.{PATCH}-SNAPSHOT.{hash}`
 
@@ -169,6 +169,20 @@ _Example3 (with breaking message):_
                                          \\
                                          message: "breaking: removed api parameter"
 ```
+
+### Configuration
+
+You can configure the action with various inputs, a list of which has been provided below:
+
+| Name             | Description                                                                                     | Default Value |
+|------------------|-------------------------------------------------------------------------------------------------|---------------|
+| tool-version     | The version of the tool to run                                                                  | latest        |
+| release-branch   | The name of the master/main branch                                                              | master        |
+| dev-branch       | The name of the development branch                                                              | dev           |
+| minor-identifier | The string used to identify a minor release (wrap with '/' to match using a regular expression) | feature:      |
+| major-identifier | The string used to identify a major release (wrap with '/' to match using a regular expression) | breaking:     |
+| prefix           | The prefix used for the version name                                                            |               |
+| log-paths        | The paths used to calculate changes (comma-separated)                                           |               |
 
 ## Requirements
 

--- a/action.yml
+++ b/action.yml
@@ -53,8 +53,8 @@ runs:
             --folder /repo \
             --release-branch "${{ inputs.release-branch }}" \
             --dev-branch "${{ inputs.dev-branch }}" \
-            --minor-identifier="{{ inputs.minor-identifier }}" \
-            --major-identifier="{{ inputs.major-identifier }}" \
+            --minor-identifier="${{ inputs.minor-identifier }}" \
+            --major-identifier="${{ inputs.major-identifier }}" \
             --version-prefix "${{ inputs.prefix }}")
 
         echo "::set-output name=previous-version::$PREVIOUS_VERSION"
@@ -69,8 +69,8 @@ runs:
             --folder /repo \
             --release-branch "${{ inputs.release-branch }}" \
             --dev-branch "${{ inputs.dev-branch }}" \
-            --minor-identifier="{{ inputs.minor-identifier }}" \
-            --major-identifier="{{ inputs.major-identifier }}" \
+            --minor-identifier="${{ inputs.minor-identifier }}" \
+            --major-identifier="${{ inputs.major-identifier }}" \
             --version-prefix "${{ inputs.prefix }}")
 
         echo "::set-output name=version::$VERSION"

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: 'The name of the dev branch'
     required: true
     default: dev
+  minor-identifier:
+    description: 'The string or regex to identify a minor release commit'
+    required: true
+    default: 'feature:'
+  major-identifier:
+    description: 'The string or regex to identify a major release commit'
+    required: true
+    default: 'breaking:'
   prefix:
     description: 'The prefix to use in the version'
     required: false
@@ -45,6 +53,8 @@ runs:
             --folder /repo \
             --release-branch "${{ inputs.release-branch }}" \
             --dev-branch "${{ inputs.dev-branch }}" \
+            --minor-identifier="{{ inputs.minor-identifier }}" \
+            --major-identifier="{{ inputs.major-identifier }}" \
             --version-prefix "${{ inputs.prefix }}")
 
         echo "::set-output name=previous-version::$PREVIOUS_VERSION"
@@ -59,6 +69,8 @@ runs:
             --folder /repo \
             --release-branch "${{ inputs.release-branch }}" \
             --dev-branch "${{ inputs.dev-branch }}" \
+            --minor-identifier="{{ inputs.minor-identifier }}" \
+            --major-identifier="{{ inputs.major-identifier }}" \
             --version-prefix "${{ inputs.prefix }}")
 
         echo "::set-output name=version::$VERSION"

--- a/spec/git-version-spec.cr
+++ b/spec/git-version-spec.cr
@@ -10,7 +10,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b #{git.release_branch})
@@ -59,7 +59,7 @@ describe GitVersion do
       tmp.exec %(git checkout -b my-fancy.branch)
       tmp.exec %(git commit --no-gpg-sign --allow-empty -m "2")
 
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       hash = git.current_commit_hash
 
@@ -82,7 +82,7 @@ describe GitVersion do
 
       tmp.exec %(git checkout -b dev)
 
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git commit --no-gpg-sign --allow-empty -m "breaking: XYZ")
 
@@ -116,7 +116,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -180,7 +180,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -209,7 +209,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -227,7 +227,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -251,7 +251,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -301,7 +301,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -331,7 +331,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -363,7 +363,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -391,7 +391,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -419,7 +419,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -438,7 +438,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -459,7 +459,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -476,7 +476,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -496,7 +496,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir, "v")
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir, "v")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -515,7 +515,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir, "v")
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir, "v")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -533,7 +533,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir, "v")
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir, "v")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -551,7 +551,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -572,7 +572,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir, "", "dir2/")
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir, "", "dir2/")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -601,7 +601,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir, "", "dir1/ dir3/")
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir, "", "dir1/ dir3/")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -640,7 +640,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir, "", "dir2/ dir3/")
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir, "", "dir2/ dir3/")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -678,7 +678,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir, "", "dir1/")
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir, "", "dir1/")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -702,7 +702,7 @@ describe GitVersion do
     tmp = InTmp.new
 
     begin
-      git = GitVersion::Git.new("dev", "master", tmp.@tmpdir, "dir2-", "dir2/ dir3/")
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir, "dir2-", "dir2/ dir3/")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -743,7 +743,7 @@ it "get previous version - first commit" do
   tmp = InTmp.new
 
   begin
-    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir)
+    git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -762,7 +762,7 @@ it "get previous version - first commit w/ prefix" do
   tmp = InTmp.new
 
   begin
-    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir, "v")
+    git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir, "v")
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -780,7 +780,7 @@ it "get previous version - pre-tagged" do
   tmp = InTmp.new
 
   begin
-    git = GitVersion::Git.new("dev", "master", tmp.@tmpdir, "v")
+    git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir, "v")
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)

--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -13,6 +13,16 @@ module GitVersion
   class Git
     def initialize(@dev_branch : String, @release_branch : String, @minor_identifier : String, @major_identifier : String,
                    @folder = FileUtils.pwd, @prefix : String = "", @log_paths : String = "")
+      @major_id_is_regex = false
+      @minor_id_is_regex = false
+      if match = /\/(.*)\//.match(@major_identifier)
+        @major_identifier = match[1]
+        @major_id_is_regex = true
+      end
+      if match = /\/(.*)\//.match(@minor_identifier)
+        @minor_identifier = match[1]
+        @minor_id_is_regex = true
+      end
       #
     end
 
@@ -136,7 +146,17 @@ module GitVersion
       major = false
       get_commits_since(previous_tag).each do |c|
         commit = c.downcase
-        if /#{@major_identifier}/.match(commit)
+        match = false
+        if @major_id_is_regex
+          if /#{@major_identifier}/.match(commit)
+            match = true
+          end
+        else
+          if commit.includes?(@major_identifier)
+            match = true
+          end
+        end
+        if match
           previous_version =
             SemanticVersion.new(
               previous_version.major + 1,
@@ -153,7 +173,17 @@ module GitVersion
       if !major
         get_commits_since(previous_tag).each do |c|
           commit = c.downcase
-          if /#{@minor_identifier}/.match(commit)
+          match = false
+          if @minor_id_is_regex
+            if /#{@minor_identifier}/.match(commit)
+              match = true
+            end
+          else
+            if commit.includes?(@minor_identifier)
+              match = true
+            end
+          end
+          if match
             previous_version =
               SemanticVersion.new(
                 previous_version.major,

--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -10,11 +10,8 @@ module GitVersion
 
   DEV_BRANCH_SUFFIX = "SNAPSHOT"
 
-  MAJOR_BUMP_COMMENT = "breaking:"
-  MINOR_BUMP_COMMENT = "feature:"
-
   class Git
-    def initialize(@dev_branch : String, @release_branch : String = "master",
+    def initialize(@dev_branch : String, @release_branch : String, @minor_identifier : String, @major_identifier : String,
                    @folder = FileUtils.pwd, @prefix : String = "", @log_paths : String = "")
       #
     end
@@ -139,7 +136,7 @@ module GitVersion
       major = false
       get_commits_since(previous_tag).each do |c|
         commit = c.downcase
-        if commit.includes?(MAJOR_BUMP_COMMENT)
+        if /#{@major_identifier}/.match(commit)
           previous_version =
             SemanticVersion.new(
               previous_version.major + 1,
@@ -156,7 +153,7 @@ module GitVersion
       if !major
         get_commits_since(previous_tag).each do |c|
           commit = c.downcase
-          if commit.includes?(MINOR_BUMP_COMMENT)
+          if /#{@minor_identifier}/.match(commit)
             previous_version =
               SemanticVersion.new(
                 previous_version.major,

--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -146,15 +146,10 @@ module GitVersion
       major = false
       get_commits_since(previous_tag).each do |c|
         commit = c.downcase
-        match = false
-        if @major_id_is_regex
-          if /#{@major_identifier}/.match(commit)
-            match = true
-          end
+        match = if @major_id_is_regex
+          /#{@major_identifier}/.match(commit)
         else
-          if commit.includes?(@major_identifier)
-            match = true
-          end
+          commit.includes?(@major_identifier)
         end
         if match
           previous_version =
@@ -173,15 +168,10 @@ module GitVersion
       if !major
         get_commits_since(previous_tag).each do |c|
           commit = c.downcase
-          match = false
-          if @minor_id_is_regex
-            if /#{@minor_identifier}/.match(commit)
-              match = true
-            end
+          match = if @minor_id_is_regex
+            /#{@minor_identifier}/.match(commit)
           else
-            if commit.includes?(@minor_identifier)
-              match = true
-            end
+            commit.includes?(@minor_identifier)
           end
           if match
             previous_version =

--- a/src/main.cr
+++ b/src/main.cr
@@ -7,6 +7,8 @@ require "./git-version"
 previous_version = false
 dev_branch = "dev"
 release_branch = "master"
+minor_identifier = "feature:"
+major_identifier = "breaking:"
 prefix = ""
 log_paths = ""
 
@@ -17,6 +19,8 @@ OptionParser.parse! do |parser|
   parser.on("-f FOLDER", "--folder=FOLDER", "Execute the command in the defined folder") { |f| folder = f }
   parser.on("-b BRANCH", "--dev-branch=BRANCH", "Specifies the development branch") { |branch| dev_branch = branch }
   parser.on("-r BRANCH", "--release-branch=BRANCH", "Specifies the release branch") { |branch| release_branch = branch }
+  parser.on("--minor-identifier=IDENTIFIER", "Specifies the string or regex to identify a minor release commit with") { |identifier| minor_identifier = identifier }
+  parser.on("--major-identifier=IDENTIFIER", "Specifies the string or regex to identify a major release commit with") { |identifier| major_identifier = identifier }
   parser.on("-p PREFIX", "--version-prefix=PREFIX", "Specifies a version prefix") { |p| prefix = p }
   parser.on("-l PATH", "--log-paths=PATH", "") { |path| log_paths = path }
   parser.on("--previous-version", "Returns the previous tag instead of calculating a new one") { previous_version=true }
@@ -28,7 +32,7 @@ OptionParser.parse! do |parser|
   end
 end
 
-git = GitVersion::Git.new(dev_branch, release_branch, folder, prefix, log_paths)
+git = GitVersion::Git.new(dev_branch, release_branch, minor_identifier, major_identifier, folder, prefix, log_paths)
 
 if previous_version
   puts "#{git.get_previous_version}"

--- a/src/main.cr
+++ b/src/main.cr
@@ -19,8 +19,10 @@ OptionParser.parse! do |parser|
   parser.on("-f FOLDER", "--folder=FOLDER", "Execute the command in the defined folder") { |f| folder = f }
   parser.on("-b BRANCH", "--dev-branch=BRANCH", "Specifies the development branch") { |branch| dev_branch = branch }
   parser.on("-r BRANCH", "--release-branch=BRANCH", "Specifies the release branch") { |branch| release_branch = branch }
-  parser.on("--minor-identifier=IDENTIFIER", "Specifies the string or regex to identify a minor release commit with") { |identifier| minor_identifier = identifier }
-  parser.on("--major-identifier=IDENTIFIER", "Specifies the string or regex to identify a major release commit with") { |identifier| major_identifier = identifier }
+  parser.on("--minor-identifier=IDENTIFIER",
+    "Specifies the string or regex to identify a minor release commit with") { |identifier| minor_identifier = identifier }
+  parser.on("--major-identifier=IDENTIFIER",
+    "Specifies the string or regex to identify a major release commit with") { |identifier| major_identifier = identifier }
   parser.on("-p PREFIX", "--version-prefix=PREFIX", "Specifies a version prefix") { |p| prefix = p }
   parser.on("-l PATH", "--log-paths=PATH", "") { |path| log_paths = path }
   parser.on("--previous-version", "Returns the previous tag instead of calculating a new one") { previous_version=true }


### PR DESCRIPTION
This commit replaces the strings used to identify minor and major commits with a configurable regex.