### PR TITLE
Add output usage for clearer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ jobs:
           fetch-depth: 0                # fetch the whole repo history
 
       - name: Git Version
-        uses: codacy/git-version@2.5.4
+        id: version
+        uses: codacy/git-version@2.7.1
+      
+      - name: Use the version
+        run: |
+          echo ${{ steps.version.outputs.version }}
+      - name: Use the previous version
+        run: |
+          echo ${{ steps.version.outputs.previous-version }}
 ```
 
 ### Mono-Repo


### PR DESCRIPTION
Currently it's not obvious that the output of the action is provided as the "version" output to the step. Adding it into the readme so that the usage is easier to understand.