### PR TITLE
fix: Add log-paths to docker run parameters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,8 @@ runs:
             --dev-branch "${{ inputs.dev-branch }}" \
             --minor-identifier="${{ inputs.minor-identifier }}" \
             --major-identifier="${{ inputs.major-identifier }}" \
-            --version-prefix "${{ inputs.prefix }}")
+            --log-paths="${{ inputs.log-paths }}" \
+            --version-prefix "${{ inputs.prefix }}")         
 
         echo "::set-output name=version::$VERSION"
         echo "New Version: $VERSION"


### PR DESCRIPTION
I have added missed --log-paths parameter to the /bin/git-version execution