### PR TITLE
fix: migrate away from ::set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
             --major-identifier="${{ inputs.major-identifier }}" \
             --version-prefix "${{ inputs.prefix }}")
 
-        echo "::set-output name=previous-version::$PREVIOUS_VERSION"
+        echo "previous-version=$PREVIOUS_VERSION" >> $GITHUB_OUTPUT
         echo "Previous Version: $PREVIOUS_VERSION"
     - id: version
       shell: bash
@@ -73,5 +73,5 @@ runs:
             --major-identifier="${{ inputs.major-identifier }}" \
             --version-prefix "${{ inputs.prefix }}")
 
-        echo "::set-output name=version::$VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "New Version: $VERSION"


### PR DESCRIPTION
This change is noted in warnings output from workflows using this action.

For reference, they link to [this blog article](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) related to the change.