### PR TITLE
fix: Mark repo dir as safe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --update --no-cache git
 
 COPY --from=builder /workspace/bin/git-version /bin
 
-RUN mkdir -p /repo
+RUN mkdir -p /repo && git config --global --add safe.directory /repo
 VOLUME /repo
 
 CMD ["/bin/git-version", "--folder=/repo"]


### PR DESCRIPTION
Fixes an issue where git commands fail due to the user running the script (and thus, the git command) not owning the files in the /repo folder.