### PR TITLE
Add quotes around browser_download_url jq query

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
       run: |
         set -eo pipefail
         if [ "${{ inputs.tool-version }}" = "latest" ]; then
-          download_url="$(curl -Ls https://api.github.com/repos/codacy/git-version/releases/latest | jq -r .assets[0].browser_download_url)"
+          download_url="$(curl -Ls https://api.github.com/repos/codacy/git-version/releases/latest | jq -r '.assets[0].browser_download_url')"
         else
           download_url="https://github.com/codacy/git-version/releases/download/${{ inputs.tool-version }}/git-version"
         fi


### PR DESCRIPTION
seemed to be causing this error: "no matches found: .assets[0].browser_download_url"

because its storing the output it possibly doesnt recognise the error?
```
echo "$(curl -Ls https://api.github.com/repos/codacy/git-version/releases/latest | jq -r .assets[0].browser_download_url)"
zsh: no matches found: .assets[0].browser_download_url
```

but with the quotes you get the correct url
```
echo "$(curl -Ls https://api.github.com/repos/codacy/git-version/releases/latest | jq -r '.assets[0].browser_download_url')"
https://github.com/codacy/git-version/releases/download/2.8.0/git-version
```