### PR TITLE
fix: add sha prefix to versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@9.3.1
+  codacy: codacy/base@12.2.0
 
 # Re-usable blocks to reduce boilerplate in job definitions.
 references:

--- a/spec/git-version-spec.cr
+++ b/spec/git-version-spec.cr
@@ -27,8 +27,6 @@ describe GitVersion do
 
       tag_on_master.should eq(["1.0.0"])
 
-      current_branch = git.current_branch_or_tag
-
       hash = git.current_commit_hash
       hashWithoutPrefix = git.current_commit_hash_without_prefix
 

--- a/spec/git-version-spec.cr
+++ b/spec/git-version-spec.cr
@@ -30,7 +30,7 @@ describe GitVersion do
       hash = git.current_commit_hash
       hashWithoutPrefix = git.current_commit_hash_without_prefix
 
-      hash.should eq("sha#{hashWithoutPrefix}")
+      hash.should eq("sha.#{hashWithoutPrefix}")
     end
   end
   it "should get the correct version in master and dev branch" do

--- a/spec/git-version-spec.cr
+++ b/spec/git-version-spec.cr
@@ -6,6 +6,35 @@ require "../src/git-version"
 
 include Utils
 describe GitVersion do
+  it "should match hash with hash without prefix" do
+    tmp = InTmp.new
+    begin
+      git = GitVersion::Git.new("dev", "master", "feature:", "breaking:", tmp.@tmpdir)
+
+      tmp.exec %(git init)
+      tmp.exec %(git checkout -b #{git.release_branch})
+      tmp.exec %(git commit --no-gpg-sign --allow-empty -m "1")
+      tmp.exec %(git tag "1.0.0")
+
+      version = git.get_new_version
+
+      version.should eq("1.0.1")
+
+      tmp.exec %(git checkout -b dev)
+      tmp.exec %(git commit --no-gpg-sign --allow-empty -m "2")
+
+      tag_on_master = git.tags_by_branch("#{git.release_branch}")
+
+      tag_on_master.should eq(["1.0.0"])
+
+      current_branch = git.current_branch_or_tag
+
+      hash = git.current_commit_hash
+      hashWithoutPrefix = git.current_commit_hash_without_prefix
+
+      hash.should eq("sha#{hashWithoutPrefix}")
+    end
+  end
   it "should get the correct version in master and dev branch" do
     tmp = InTmp.new
 

--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -78,6 +78,11 @@ module GitVersion
       return "sha" + sha
     end
 
+    def current_commit_hash_without_prefix : String
+      cmd = "git rev-parse --verify HEAD --short"
+      return (exec cmd)[0].rjust(7, '0')
+    end
+
     def commits_distance(tag : String | Nil)
       if tag.nil?
         return (exec "git rev-list --count HEAD")[0]
@@ -99,7 +104,7 @@ module GitVersion
       return [] of String
     end
 
-    def get_previous_tag_and_version: Tuple(String | Nil, SemanticVersion)
+    def get_previous_tag_and_version : Tuple(String | Nil, SemanticVersion)
       cb = current_branch_or_tag
 
       branch_tags = tags_by_branch(cb)
@@ -127,7 +132,7 @@ module GitVersion
       return {previous_tag, previous_version}
     end
 
-    def get_previous_version: String
+    def get_previous_version : String
       lt, lv = get_previous_tag_and_version
       return lt ? lt : add_prefix(lv.to_s)
     end

--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -74,7 +74,8 @@ module GitVersion
 
     def current_commit_hash : String
       cmd = "git rev-parse --verify HEAD --short"
-      return (exec cmd)[0].rjust(7, '0')
+      sha = (exec cmd)[0].rjust(7, '0')
+      return "sha" + sha
     end
 
     def commits_distance(tag : String | Nil)

--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -74,13 +74,13 @@ module GitVersion
 
     def current_commit_hash : String
       cmd = "git rev-parse --verify HEAD --short"
-      sha = (exec cmd)[0].rjust(7, '0')
-      return "sha" + sha
+      sha = (exec cmd)[0].strip
+      return "sha." + sha
     end
 
     def current_commit_hash_without_prefix : String
       cmd = "git rev-parse --verify HEAD --short"
-      return (exec cmd)[0].rjust(7, '0')
+      sha = (exec cmd)[0].strip
     end
 
     def commits_distance(tag : String | Nil)

--- a/src/git-version.cr
+++ b/src/git-version.cr
@@ -80,7 +80,7 @@ module GitVersion
 
     def current_commit_hash_without_prefix : String
       cmd = "git rev-parse --verify HEAD --short"
-      sha = (exec cmd)[0].strip
+      return (exec cmd)[0].strip
     end
 
     def commits_distance(tag : String | Nil)


### PR DESCRIPTION
This fix is to solve the invalid semver versioning pointed in the ticket [[GH#53]](https://codacy.atlassian.net/browse/CY-5396?atlOrigin=eyJpIjoiYTBhNzkyMjAxNzk4NDgyNjkyZThiNjVmNDcxYzc4MjciLCJwIjoiaiJ9)