### PR TITLE
fix: Add log-paths to action parameters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,7 @@ runs:
             --dev-branch "${{ inputs.dev-branch }}" \
             --minor-identifier="${{ inputs.minor-identifier }}" \
             --major-identifier="${{ inputs.major-identifier }}" \
+            --log-paths="${{ inputs.log-paths }}" \ 
             ${{ inputs.skip-prerelease == 'true' && '--skip-prerelease' || '' }} \
             --version-prefix "${{ inputs.prefix }}")
 


### PR DESCRIPTION
The input for log-path is not provided anywhere. So the value you add to the input of the action is not used