### PR TITLE
fix: remove breaking space in action.yaml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
             --dev-branch "${{ inputs.dev-branch }}" \
             --minor-identifier="${{ inputs.minor-identifier }}" \
             --major-identifier="${{ inputs.major-identifier }}" \
-            --log-paths="${{ inputs.log-paths }}" \ 
+            --log-paths="${{ inputs.log-paths }}" \
             ${{ inputs.skip-prerelease == 'true' && '--skip-prerelease' || '' }} \
             --version-prefix "${{ inputs.prefix }}")
         


### PR DESCRIPTION
An extra space after the script in the action.yaml was causing an error to appear once the version was calculated. This was reported in the [issue](https://github.com/codacy/git-version/issues/110)